### PR TITLE
Allow deployment of scraper to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,5 @@
+# Define the process that will handle inbound HTTP traffic
 web: node index.js
+
+# Define a utility which can be called through Heroku to run the web scraper.
 scrape: python scraper/scraper.py

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node index.js
+scrape: python scraper/scraper.py

--- a/README.md
+++ b/README.md
@@ -6,15 +6,32 @@ A visual tool to show the relationships between courses at UVic.
 ## Project structure
 The root directory contains the NodeJS app for the website. 
 
+`/scraper/` contains the Python web scraper. A root-level `requirements.txt` file is used to signal to the Heroku 'Buildpack' system that this is a Python application.
+
 ## Github/git
 `master` branch is protected and requires pull requests to be updated.
 
 Name dev branches as `dev/<contributor name>/<feature>`.
 
-## CI and Deploymet
-All branches are automatically built by [Travis](travis-ci.com). Heroku monitors `master` and automatically deploys if the CI build succeeds.
+## CI / CD
+
+### Travis (CI)
+All branches are automatically built by [Travis](travis-ci.com). 
 
 We are hosting on travis-ci.__com__, not travis-ci.__org__. If you are using Travis' CLI (you can get it with `gem install travis`), then you will need to add the `--pro` or `--com` flag to each command as it defaults to the .org server.
+
+You can manually trigger a Travis build through the website. 
+
+See `.travis.yml` for configuration.
+
+### Heroku (Deployment)
+[Heroku](https://dashboard.heroku.com/apps/coursechart) monitors `master` and automatically deploys it each time a pull request is merged if and only if the CI build succeeds. 
+
+Dev branches can be deployed manually on Heroku via the web interface, or locally using `heroku local` (requires the Heroku CLI).
+
+See `Procfile` and Heroku website for configuration.
+
+You can run `heroku run scrape -a coursechart` to manually run the Python scraper.
 
 ## Outstanding
 * DB setup 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# This file is intentionally empty and is used to tell Heroku that this build 
+# uses Python. The line below includes the specified requirements file.
+-r scraper/requirements.txt


### PR DESCRIPTION
**Background**
Heroku has for some reason decided that deployments with [buildpacks ](https://devcenter.heroku.com/articles/buildpacks)for a given language will fail if you don't put files which trigger a detection check in the root directory.

They have also made it impossible to define separate `Procfile`s for different directories. I found a few third party buildpacks that do hacky work arounds copying files back and forth, but instead I think the cleanest thing to do is add dummy "signal" files to the root which forward to the appropriate subdir. It's not ideal, but it is relatively easy to understand and not hidden in configuration on Heroku that might be really hard to find unless you know where to look.

**Actual Changes**

1. For Python, I added a `requirements.txt` to the root which requires scraper dependencies. We can do the same for the Node app in the future, but it looks a little more complicated so I'm leaving it for now.
2. Added documentation on how CI/CD stuff works.
3. Added a `scraper` command which runs the Python code that we can use to test the scraper, and run it on a schedule once it actually does something.