### PR TITLE
Add npm start script; use it instead of manually running index.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ jobs:
     - language: node_js
       node_js: node  # Use the latest stable version of Node
       script: 
-      - node server/index.js &  # Run the server in the background
+      - npm start &  # Run the server in the background
       - npm test

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 # Define the process that will handle inbound HTTP traffic
-web: node index.js
+web: npm start
 
 # Define a utility which can be called through Heroku to run the web scraper.
 scrape: python scraper/scraper.py

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A visual tool to show the relationships between courses at UVic.",
   "main": "server/index.js",
   "scripts": {
-    "test": "jshint server/index.js"
+    "test": "jshint server/index.js",
+    "start": "node server/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As evidenced by my last PR breaking the deploy, it's better to specify a single source of truth for the command to run the server. This is now `package.json`. `npm start` is now the canonical way to run the server and the rest of the build files use this instead of hardcoding the path to and name of the entry point js file.