### PR TITLE
Scrape and Store Course URLs in Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Dev branches can be deployed manually on Heroku via the web interface, or locall
 See `Procfile` and Heroku website for configuration.
 
 You can run `heroku run scrape -a coursechart` to manually run the Python scraper.
+
+## Database
+
+The web scraper saves the course data in a postgres database hosted via Heroku ([documentation](https://devcenter.heroku.com/articles/heroku-postgresql)). 
+
+You can open a postgres terminal with `heroku pg:psql`. This requires installing Postgres. On windows, run the installer and add the `bin` directory to your PATH.

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,0 +1,9 @@
+# Web Scraper
+
+The main script for the scraper utility is `scraper.py`. It uses Selenium and ChromeDriver to navigate to each course page in the uvic academic calendar, scrape data and metadata, and store those data in the postgres database.
+
+## Local development environment
+
+Chrome and [ChromeDriver](https://chromedriver.chromium.org/downloads) are both needed for local development, and you'll need the correct version of chromedriver for your version of Chrome. See `driver_setup.py` for a more in depth description of how the driver must be configured.
+
+To connect the scraper to a database, set the `DATABASE_URL` environment variable.

--- a/scraper/class_listing.py
+++ b/scraper/class_listing.py
@@ -5,26 +5,17 @@
 class ClassListing:
     '''Represents a listing in the academic calendar'''
 
-    def __init__(self, name, code):
+    def __init__(self, name, code, url):
         '''Creates a ClassListing'''
         self.name = name
         self.code = code
+        self.url = url
 
-    def get_name(self):
-        '''Returns the course name'''
-        return self.name
-
-    def get_code(self):
-        '''Returns the course code'''
-        return self.code
-
-
-def get_from_web_element(class_element):
+def get_from_web_element(class_element, url):
     '''Converts a selenium web element into a ClassListing instance'''
     course_desc = class_element.find_element_by_tag_name('h2').text
     (course_code, course_name) = parse_course_description(course_desc)
-
-    return ClassListing(course_name, course_code)
+    return ClassListing(course_name, course_code, url)
 
 
 def parse_course_description(desc):

--- a/scraper/db.py
+++ b/scraper/db.py
@@ -5,6 +5,7 @@ from os import environ
 import psycopg2
 
 
+# TODO update logging to work for multiple processes
 LOGGER = logging.getLogger(__name__)
 
 

--- a/scraper/db.py
+++ b/scraper/db.py
@@ -18,10 +18,10 @@ def connect(url=None):
         If no URL is provided, use the DATABASE_URL environment variable.
     '''
     if url is None:
-        envUrl = _try_get_url()
-        if envUrl is None:
+        env_url = _try_get_url()
+        if env_url is None:
             raise EnvironmentError('Unable to read URL from environment')
-        url = envUrl
+        url = env_url
     try:
         connection_params_dict = psycopg2.extensions.parse_dsn(url)
         connection = psycopg2.connect(**connection_params_dict)

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -198,13 +198,19 @@ def get_and_wait_for_ajax_complete(link, browser):
     wait.until(header_updated)
 
 
+# Silently allow updates
+INSERT_URL_QUERY_TEMPLATE = sql.SQL('''INSERT INTO course_urls 
+VALUES (%s, %s) 
+ON CONFLICT (course_code) 
+DO UPDATE SET url=EXCLUDED.url
+''')
+
+
 def send_to_database(course, db_connection):
     '''Saves the data about the course to the Postgres database'''
     try: 
-        # TODO deal with case of the key already existing in the table
         cursor = db_connection.cursor() 
-        query_template = sql.SQL('INSERT INTO course_urls VALUES (%s, %s)')   
-        cursor.execute(query_template, (course.code, course.url))
+        cursor.execute(INSERT_URL_QUERY_TEMPLATE, (course.code, course.url))
         db_connection.commit()
 
     except Exception as error:

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -19,6 +19,8 @@ import db
 # TODO prevent Heroku from putting the app to sleep while the scraper is running.
 
 
+# TODO Logging from sub-processes does not work.
+# https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes
 LOGGER = logging.getLogger(__name__)
 
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,6 +1,7 @@
 '''Entry point script for the web scraper.
 
-Uses Selenium to scrape the UVic academic calendar for course relationships.
+Uses Selenium to scrape the UVic academic calendar for course relationships 
+and saves the information to the Postgres database
 '''
 
 import logging
@@ -154,7 +155,7 @@ def crawl_course_page(link, browser):
     get_and_wait_for_ajax_complete(link, browser)
 
     catalog_element = get_catalog_element(browser)
-    listing = class_listing.get_from_web_element(catalog_element)
+    listing = class_listing.get_from_web_element(catalog_element, link)
     send_to_database(listing)
 
 
@@ -197,11 +198,9 @@ def get_and_wait_for_ajax_complete(link, browser):
 
 def send_to_database(course):
     '''Saves the data about the course to the Postgres database'''
-    # TODO Implement
+    # TODO actually insert the course and url into the db
     print(course.code + " - " + course.name)
+    print(course.url)
 
 if __name__ == '__main__':
-    # TODO remove this once actual database functions are implemented & available
-    db.print_test_table()
-
     main()


### PR DESCRIPTION
Extracts the course code and url from each course page and stores them in the `course_urls` table. There's a dataclip in heroku (go to Resources > Heoku Postgres > Data Clips) where you can see the content of the table.

I wrote most of this last August and picked it up again today so it may be a bit disjointed. The only additions I made since then were to add in some handling for pages that don't load within the allowed timeout and update the documentation with what I needed to get set up again.